### PR TITLE
feat: publish slot-swap-warmup experiment (S1-S5 executed)

### DIFF
--- a/docs/app-service/access-restrictions-scm/overview.md
+++ b/docs/app-service/access-restrictions-scm/overview.md
@@ -15,8 +15,8 @@ validation:
 
 # Access Restrictions: Main Site vs SCM / Kudu Reachability
 
-!!! info "Status: Draft - Awaiting Execution"
-    This experiment design is complete and ready for lab execution. No Azure resources were created and no live measurements are recorded on this page yet.
+!!! success "Status: Published"
+    Experiment executed on 2026-05-01. Korea Central, Linux P1v3, Python 3.11. Scenarios S1, S2, S3, S5, S6 completed on real Azure infrastructure. S4 (private endpoint + access restrictions combined) not executed — VNet-internal client not available in this lab environment.
 
 ## 1. Question
 
@@ -561,57 +561,138 @@ az group delete --name "$RG" --yes --no-wait
 
 ## 10. Results
 
-Awaiting execution.
+!!! info "Environment: Korea Central, Linux P1v3, Python 3.11, 2026-05-01"
 
-Populate this section with:
+### Baseline (no restrictions, no private endpoint)
 
-1. Completed scenario matrix from section 8.12
-2. Sample request/response transcripts for each distinct outcome (`200`, `401`, `403`, timeout, DNS failure)
-3. DNS resolution results for app and SCM hostnames from public and VNet-connected clients
-4. Access restriction rule dumps per scenario
-5. Health check log evidence and any instance-state changes
-6. zipdeploy and deployment-history outputs under each SCM restriction mode
+| Endpoint | HTTP status | Notes |
+|----------|-------------|-------|
+| Main `/` | 200 | Public access, public IP |
+| Main `/healthz` | 200 | |
+| SCM `/api/settings` | 200 | Basic auth enabled |
+| SCM `/api/deployments` | 200 | |
+| DNS: `app.azurewebsites.net` | `20.41.66.225` | Public IP |
+| DNS: `app.scm.azurewebsites.net` | `20.41.66.225` | Same public IP |
+| SCM `scmIpSecurityRestrictionsUseMain` | `false` | Default — SCM rules independent |
+
+### Scenario S1: Main restricted (bogus IP only), SCM unrestricted (`scmUsesMain=false`)
+
+| Endpoint | HTTP status | Notes |
+|----------|-------------|-------|
+| Main `/` | **403** | Our workstation IP denied by main rules |
+| Main `/healthz` | **403** | Same — all main paths blocked |
+| SCM `/api/settings` | **200** | SCM rules independent, no SCM restriction |
+| SCM `/api/deployments` | **200** | |
+
+**Key observation**: Main site blocked, SCM/Kudu fully reachable — independent control planes confirmed **[Observed]**.
+
+### Scenario S2: Main allows workstation IP; SCM allows only bogus IP (`scmUsesMain=false`)
+
+| Endpoint | HTTP status | Notes |
+|----------|-------------|-------|
+| Main `/` | **200** | Workstation IP in main allow list |
+| SCM `/api/settings` | **403** | Workstation IP not in SCM allow list |
+| SCM `/api/deployments` | **403** | |
+
+**Key observation**: Main and SCM can be independently allowed/denied by different source IP rules — they are truly separate rule sets **[Observed]**.
+
+### Scenario S3: Private endpoint added, no access restrictions
+
+| Endpoint | HTTP status | DNS resolution |
+|----------|-------------|----------------|
+| Main `/` | **403** | `20.41.66.225` (public IP — unchanged) |
+| Main `/healthz` | **403** | |
+| SCM `/api/settings` | **403** | |
+| SCM `/api/deployments` | **403** | |
+
+**Key observation**: Private endpoint addition alone — without any access restriction rules — caused `403` on **both** main site and SCM from the public internet **[Observed]**. DNS still resolved to the public IP; the block is enforced at the App Service layer, not via DNS. SCM/Kudu followed the same behavior as the main site when the private endpoint was the only change **[Observed]**.
+
+### Scenario S5: Main restricted (all IPs denied), health check configured on `/healthz`
+
+| Time | Instance state | Main `/healthz` from workstation |
+|------|---------------|----------------------------------|
+| T=0  | READY | 403 |
+| T=3min | **READY** | 403 |
+| T=5min | **READY** | 403 |
+
+**Key observation**: Instance remained `READY` throughout — health check probe continued to succeed even though all external IPs (including our workstation) were blocked **[Observed]**. The platform health check probe bypasses access restrictions; it does not originate from a routable external IP that would be subject to the IP allow/deny rules **[Strongly Suggested]**.
+
+### Scenario S6: Main site open, SCM restricted (bogus IP only)
+
+| Operation | Result | Error |
+|-----------|--------|-------|
+| Main `/` | **200** | — |
+| SCM `/api/settings` | **403** | Access restriction |
+| SCM `/api/deployments` | **403** | Access restriction |
+| `curl` zipdeploy via SCM API | **403** | Access restriction |
+| `az webapp deploy` (zip) | **Failed** | `Status Code: 403` — Kudu warmup and deploy both blocked |
+
+**Key observation**: SCM restriction blocked `zipdeploy`, Kudu API access, and `az webapp deploy` while the main site remained fully accessible **[Observed]**. The deployment CLI route goes through `*.scm.azurewebsites.net` — SCM reachability is a prerequisite for all zip-based deployments **[Observed]**.
 
 ## 11. Interpretation
 
-Awaiting execution. Use evidence tags when filling this section.
+**H1 — Main and SCM restrictions are independently configurable: CONFIRMED [Observed]**
+S1 and S2 both demonstrated that `ipSecurityRestrictions` (main) and `scmIpSecurityRestrictions` (SCM) are evaluated independently when `scmIpSecurityRestrictionsUseMain=false`. A source IP blocked on main can reach SCM, and vice versa **[Observed]**.
 
-Suggested interpretation structure:
+**H2 — Private endpoint causes public 403 on both main and SCM: CONFIRMED [Observed]**
+S3 showed that adding a private endpoint alone — without any explicit access restriction rules — produced `403` on both `*.azurewebsites.net` and `*.scm.azurewebsites.net` from the public internet **[Observed]**. DNS continued to resolve to the public IP; the block is not DNS-based **[Observed]**. SCM did not maintain a separate public path after the private endpoint was added in this test **[Observed]**. The underlying mechanism (whether the PE triggers an internal public-network-access block or routes differently) was not directly verified **[Unknown]**.
 
-- **Observed**: which endpoint classes were reachable or blocked under each rule combination
-- **Measured**: counts of successful vs failed probes and deployments per scenario
-- **Correlated**: health degradation or deployment failure coinciding with a specific rule set
-- **Inferred**: which control plane applies to each endpoint type
-- **Not Proven / Unknown**: any unresolved SCM behavior under private endpoint or inherited-rule edge cases
+**H3 — Platform-originated health/warmup traffic still reached the app despite external 403: CORROBORATED [Strongly Suggested]**
+S5 showed that instance state remained `READY` for at least 5 minutes after all external IPs were denied on the main site **[Observed]**. The warmup probe succeeded at the platform layer even though the same `/healthz` path returned `403` from the external workstation **[Observed]**. This is consistent with platform-originated probe traffic not traversing the IP-based restriction layer — but the probe source IP and internal routing path were not directly captured **[Strongly Suggested]**.
+
+**H4 — SCM restrictions block zipdeploy and deployment CLI: CONFIRMED [Observed]**
+S6 confirmed that SCM restriction `403` propagates to `curl /api/zipdeploy` and `az webapp deploy --type zip` **[Observed]**. The main site was unaffected — `200` throughout — while all SCM-routed operations failed **[Observed]**.
+
+### Key discovery: Private endpoint caused public 403 on both main and SCM — VNet-internal access not verified
+
+Adding a private endpoint (no access restriction rules set) produced `403` on both main and SCM endpoints from the public internet. DNS still resolved to the public IP — the block is not DNS-based **[Observed]**. Customers who add a private endpoint expecting only the main site to be restricted will find SCM/Kudu also becomes inaccessible from public clients **[Observed]**. This experiment did not verify access from inside the VNet (S4 not executed); whether VNet-internal clients can reach both main and SCM via the private endpoint is not confirmed **[Unknown]**.
+
+### Key discovery: Platform warmup/health traffic reached the app despite external 403 — probe mechanism not directly observed
+
+Instance state remained `READY` while all external IPs were denied. Platform-originated warmup traffic succeeded even though the same `/healthz` endpoint returned `403` from outside **[Observed]**. This is consistent with the probe not traversing the IP-restriction layer, but the probe source IP was not captured **[Strongly Suggested]**.
+
+### Key discovery: SCM rules are independent by default (`scmUsesMain=false`)
+
+When `scmIpSecurityRestrictionsUseMain=false` (default), main and SCM rules are evaluated completely independently — confirmed in S1 and S2. The behavior of `scmUsesMain=true` was not tested in this experiment; its effect is noted as a known risk but is not characterized here **[Unknown]**.
 
 ## 12. What this proves
 
-Awaiting execution. After running the experiment, this section should state only the supported conclusions, for example:
+!!! success "Evidence: S1–S3, S5–S6. Korea Central, Linux P1v3, Python 3.11, 2026-05-01"
 
-- whether main-site and SCM restrictions were truly independent in practice
-- whether zipdeploy followed SCM reachability exactly
-- whether health check failed when the effective probe source was blocked
-- whether private endpoint changed only the main-site path or also affected SCM in the tested configuration
+1. **Main and SCM access restrictions are independently enforced when `scmUsesMain=false`** **[Observed]** — different source IPs can be allowed/denied on each independently; confirmed in S1 and S2
+2. **A private endpoint alone caused `403` on both main and SCM from the public internet in this test** **[Observed]** — no access restriction rule was needed; DNS still resolved to the public IP; VNet-internal access was not verified (S4 not executed)
+3. **DNS is not changed by private endpoint** **[Observed]** — `*.azurewebsites.net` and `*.scm.azurewebsites.net` continued to resolve to the public IP after PE addition
+4. **Platform warmup/probe traffic reached the app while all external IPs were denied** **[Observed]** — instance remained healthy for ≥5 minutes; the probe source did not traverse the IP restriction layer **[Strongly Suggested]**
+5. **SCM restriction blocks Kudu-based deployment paths** **[Observed]** — `curl /api/zipdeploy` and `az webapp deploy --type zip` both returned `403`; main site `200` was unaffected
+6. **`az webapp deploy --type zip` uses the SCM endpoint** **[Observed]** — it is not a privileged ARM-level channel; SCM restriction applies equally to the CLI and direct curl
 
 ## 13. What this does NOT prove
 
-Even after execution, this experiment will not by itself prove:
-
-- behavior across all App Service SKUs, regions, or Windows plans
-- behavior for ASE, ILB ASE, or App Service Environment-specific networking
-- behavior for every diagnostics surface in the Azure portal
-- all possible health check probe source identities outside the tested region and platform generation
-- behavior for deployment methods not tested here (for example, GitHub Actions task internals, MSDeploy, or custom CI runners)
+- **Behavior with `scmUsesMain=true`**: This toggle was not directly tested; whether it produces the expected main-rule inheritance on SCM under all conditions (including private endpoint) is not characterized here **[Unknown]**
+- **VNet-internal access after private endpoint**: S4 was not executed — whether both main and SCM are accessible from inside the VNet via the private endpoint is not confirmed **[Unknown]**
+- **Behavior for Windows plans or Windows Containers**: Results are for Linux P1v3 only
+- **Behavior for ASE or ILB ASE**: Different network model; access restriction semantics may differ
+- **Health check probe source IP**: The probe source was not captured; the bypass is inferred from instance state remaining healthy, not from direct traffic observation **[Strongly Suggested, not directly observed]**
+- **Deployment methods beyond Kudu/zipdeploy**: GitHub Actions (internal task), MSDeploy, FTP, and local git were not tested — only `az webapp deploy --type zip` and direct `curl /api/zipdeploy`
+- **Whether PE mechanism is public-network-access toggle or routing change**: The exact platform mechanism that produces the 403 after PE addition was not verified
 
 ## 14. Support takeaway
 
-Planned support guidance after execution:
+!!! abstract "For support engineers"
 
-1. Check whether the failing operation targets the **main site** or the **SCM site**.
-2. If deployment, Kudu, or log-stream access fails, inspect **SCM restrictions first**, not only main-site restrictions.
-3. If private endpoint is involved, verify DNS resolution and test from both public and VNet-connected paths.
-4. If health check starts failing after a network change, validate whether the effective rules still allow the probe source.
-5. Treat **Use main site rules for SCM** as a deliberate design choice, not a harmless simplification.
+    **When a customer reports unexpected 403 or deployment failures after a network configuration change:**
+
+    1. **Identify which endpoint is failing first**: Main site (`*.azurewebsites.net`) or SCM/Kudu (`*.scm.azurewebsites.net`)? These are independently controlled. A `403` on deployment does not mean the app itself is blocked, and vice versa.
+
+    2. **Check `scmIpSecurityRestrictionsUseMain`**: If `true`, SCM inherits main-site rules — restricting the main site will also restrict deployment and Kudu access. This is often set intentionally but surprises customers when deployment pipelines break after a main-site lockdown.
+
+    3. **Private endpoint caused both main and SCM to return 403 from the public internet in this test**: Customers who add a private endpoint often expect only the main site to become private. In this experiment, `*.scm.azurewebsites.net` also returned `403` from public clients after PE addition — even without any explicit access restriction rules. If Kudu or deployment access is needed from public CI/CD after PE is added, a VNet-connected runner, jump host, or self-hosted agent in the VNet is likely required. Note: VNet-internal access was not verified in this experiment.
+
+    4. **Platform warmup/health traffic appears to bypass IP-based access restrictions**: Instance state remained `READY` while all external IPs were denied. If instances are going unhealthy after a network hardening change, the restriction rules are unlikely to be the cause — look at the application health endpoint itself (startup failure, dependency, misconfigured path) rather than the IP rules. Note: the probe source was not directly captured; this is inferred from instance state.
+
+    5. **Deployment failures after SCM restriction show as `403`, not `401`**: `401` means credentials were rejected; `403` means the request was rejected by the access restriction layer before credentials were evaluated. These must be distinguished — the fix for `403` is a rule change, not a credential rotation.
+
+    6. **`az webapp deploy --type zip` goes through SCM — it is not a privileged channel**: This CLI command uses `*.scm.azurewebsites.net` and is subject to the same SCM access restrictions as a direct `curl /api/zipdeploy`. If SCM is restricted, all Kudu/zip-based deployment methods will fail. Other deployment methods (GitHub Actions internal task, MSDeploy, FTP) were not tested in this experiment.
 
 ## 15. Reproduction notes
 

--- a/docs/app-service/slot-swap-warmup/overview.md
+++ b/docs/app-service/slot-swap-warmup/overview.md
@@ -15,8 +15,8 @@ validation:
 
 # Slot Swap Warm-up and Sticky Settings
 
-!!! info "Status: Draft - Awaiting Execution"
-    This experiment design is complete, but it has not been executed yet. All procedures, expected signals, and result tables below are prepared for a future lab run on Azure App Service.
+!!! info "Status: Published"
+    Experiment executed on Azure App Service, Korea Central, Linux P1v3, Python 3.11. Scenarios S1–S5 completed. S6 (auto-swap) not executed in this run.
 
 ## 1. Question
 
@@ -691,79 +691,119 @@ az webapp deployment slot auto-swap \
 
 ## 10. Results
 
-Pending execution.
-
-Use the tables below during the live run.
+Executed on: 2026-05-01, Korea Central, Linux P1v3, Python 3.11, app `app-slot-swap-76099`.
 
 ### 10.1 Configuration movement
 
-| Scenario | Production before | Staging before | Production after | Staging after |
-|----------|-------------------|----------------|------------------|---------------|
-| `sticky_app_setting` | TBD | TBD | TBD | TBD |
-| `shared_app_setting` | TBD | TBD | TBD | TBD |
-| `sticky_connection_string` | TBD | TBD | TBD | TBD |
-| `shared_connection_string` | TBD | TBD | TBD | TBD |
+Scenario S5 (sticky vs non-sticky setting movement after swap).
+
+| Setting | Production before | Staging before | Production after | Staging after |
+|---------|-------------------|----------------|------------------|---------------|
+| `sticky_app_setting` (slot-sticky) | `prod-sticky` | `staging-sticky` | `prod-sticky` | `staging-sticky` |
+| `shared_app_setting` (non-sticky) | `prod-shared` | `staging-shared` | `staging-shared` | `prod-shared` |
+| `sticky_connection_string` (slot-sticky) | `prod-sticky.database.windows.net` | `staging-sticky.database.windows.net` | `prod-sticky.database.windows.net` | `staging-sticky.database.windows.net` |
+| `shared_connection_string` (non-sticky) | `prod-shared.database.windows.net` | `staging-shared.database.windows.net` | `staging-shared.database.windows.net` | `prod-shared.database.windows.net` |
+
+Note: `SLOT_ROLE` (non-sticky) moved with the content. `STICKY_APP_SETTING` (slot-sticky) stayed bound to the slot hostname.
 
 ### 10.2 Availability during swap
 
-| Scenario | Swap type | Warm-up configured | Health Check enabled | Startup delay | `200` count | `503` count | Other `5xx` | First stable `200` after swap |
-|----------|-----------|--------------------|----------------------|---------------|-------------|-------------|-------------|-------------------------------|
-| 1 | Manual | No | No | 0s | TBD | TBD | TBD | TBD |
-| 2 | Manual | Yes | No | 0s | TBD | TBD | TBD | TBD |
-| 3 | Manual | Optional | Yes | 0s | TBD | TBD | TBD | TBD |
-| 4 | Manual | Yes/No | Optional | 75s | TBD | TBD | TBD | TBD |
-| 6 | Auto-swap | Yes/No | Optional | varies | TBD | TBD | TBD | TBD |
+1-second probe against production hostname during each swap. 0 errors in all runs.
+
+| Scenario | Swap type | Warm-up configured | Health Check | Startup delay | `200` count | `503` count | Other `5xx` | Swap duration | First stable post-swap |
+|----------|-----------|--------------------|--------------|---------------|-------------|-------------|-------------|---------------|------------------------|
+| S1 | Manual | No | No | 0 s | 120 / 120 | 0 | 0 | 92 s | ~44 s into probe (i=44) |
+| S2 | Manual | Yes (`/warmup`, 10 s delay) | No | 0 s | 180 / 180 | 0 | 0 | 83 s | ~37 s into probe (i=37) |
+| S3 | Manual | No | Yes (staging `/health`=503) | 0 s | — | — | — | 83 s | swap completed; prod immediately unhealthy |
+| S4 | Manual | Yes (`/warmup`, 5 s delay) | No | 75 s | 300 / 300 | 0 | 0 | 161 s | ~121 s into probe (i=121) |
+
+During S1 and S2, a mixed-routing window was visible (i=44–67 in S1, i=37–44 in S2) where both `slot_role=production` and `slot_role=staging` responses appeared at the production hostname within the same ~10–23 s window before stabilizing.
 
 ### 10.3 Swap command outcome
 
-| Scenario | Swap command result | Observed activity log summary | Notes |
-|----------|---------------------|-------------------------------|-------|
-| 1 | TBD | TBD | TBD |
-| 2 | TBD | TBD | TBD |
-| 3 | TBD | TBD | TBD |
-| 4 | TBD | TBD | TBD |
-| 5 | TBD | TBD | TBD |
-| 6 | TBD | TBD | TBD |
+| Scenario | Swap command result | Notes |
+|----------|---------------------|-------|
+| S1 | Exit 0, 92 s | Baseline — no startup delay, no warm-up |
+| S2 | Exit 0, 83 s | Warmup path hit before cutover; first post-swap response had `warmed_up=true` |
+| S3 | Exit 0, 83 s | Swap succeeded despite staging `/health` returning 503 throughout |
+| S4 | Exit 0, 161 s | Swap waited for 75 s startup + 5 s warmup before cutting over; 0 503s |
+| S5 | Exit 0, ~80 s | Config movement observed; no availability impact |
 
 ## 11. Interpretation
 
-Pending execution.
+### H1 — Slot-sticky settings stay with the slot; non-sticky settings move with the content: CONFIRMED [Observed]
 
-Current evidence status:
+S5 showed that `STICKY_APP_SETTING` and `STICKY_DB` (both configured with `--slot-settings`) remained bound to the original slot hostname after swap **[Observed]**. `SHARED_APP_SETTING` and `SHARED_DB` (non-sticky) moved to the new production hostname along with the swapped content **[Observed]**. The separation is clean and immediate — no delay observed post-swap.
 
-- **Unknown** whether non-sticky app settings and non-sticky connection strings will show identical movement semantics in this exact Linux/Python slot configuration.
-- **Unknown** how consistently swap warm-up removes transient `503` for a slow-starting app on this SKU and region.
-- **Unknown** whether Health Check failure causes swap failure, delayed activation, or only post-swap unhealthy behavior in this test design.
+### H2 — Non-sticky connection strings move with the swapped slot configuration: CONFIRMED [Observed]
+
+`SQLAZURECONNSTR_SHARED_DB` (non-sticky) moved to the production hostname after swap; `SQLAZURECONNSTR_STICKY_DB` (slot-sticky) stayed **[Observed]**. Connection strings and app settings follow the same slot-sticky semantics when configured identically.
+
+### H3 — Swap without warm-up on a fast-starting app produced no transient 503 in this run: CONFIRMED [Observed, single run]
+
+S1 recorded 0 503s across 120 1-second probes during a manual swap with no warm-up and no startup delay **[Observed]**. Note: the 1 s probe cadence means sub-second transient failures could have been missed. A transition window (~23 s, i=44–67) was visible where the production hostname returned both `slot_role=production` and `slot_role=staging` responses before stabilizing — all were `200` **[Observed]**. Whether this transition window duration is repeatable across runs was not measured. A slow-starting or warm-up-dependent app would likely produce a different result **[Inferred]**.
+
+### H3b — Swap with warm-up configured: first post-cutover response was already warmed: CONFIRMED [Observed, single run]
+
+S2 recorded 0 503s. The first response after cutover had `warmed_up=true` **[Observed]**. This is consistent with the platform hitting `/warmup` on the staging slot before routing live traffic, but the warmup-request hit was not directly captured from platform logs — the conclusion is based on the app-side `warmup_hits` counter and `warmed_up` flag **[Strongly Suggested]**.
+
+### H4 — In this single-instance run, Health Check failure on staging did not block manual swap completion: CONFIRMED [Observed, single run, single instance]
+
+S3 showed that `az webapp deployment slot swap` returned exit 0 in 83 s even though staging `/health` returned `503` throughout **[Observed]**. Post-swap, the production hostname immediately served the unhealthy app **[Observed]**. This result is limited to: single-instance plan, default Health Check configuration, no minimum healthy-instance threshold tested. Whether Health Check failure blocks swap under multi-instance plans, specific threshold settings, or other configurations is **[Unknown]**. Health Check continued to affect post-swap instance availability and routing — it is not irrelevant to the swap outcome, only to swap command completion in this setup.
+
+### H5 — Slow-starting app with warm-up extended swap duration and produced no 503 in this run: CONFIRMED [Observed, single run]
+
+S4 showed swap duration of 161 s vs. 83–92 s for fast-starting scenarios **[Observed]**. Zero 503s were observed across 300 1-second probes **[Observed]**. The additional ~78 s over the S2 baseline is consistent with the platform waiting for the 75 s startup delay before the warmup ping could succeed, but the internal sequencing of startup completion and warmup initiation was not directly captured from platform logs **[Strongly Suggested]**.
 
 ## 12. What this proves
 
-Not yet executed.
+These results apply specifically to:
 
-Once completed, this experiment should prove only the specific behaviors observed on:
+- Azure App Service P1v3, Linux, `koreacentral`
+- Python 3.11 Flask app, one production + one staging slot
+- Manual swap (`az webapp deployment slot swap`)
+- Single-instance plan (P1v3, no scale-out)
 
-- Azure App Service P1v3
-- `koreacentral`
-- Python 3.11 on Linux
-- one production slot and one staging slot
+**Proved [Observed]:**
+
+1. Slot-sticky app settings and connection strings remain bound to the slot hostname after swap — the production hostname retains its sticky values regardless of what was in staging.
+2. Non-sticky app settings and connection strings move with the swapped content — the production hostname reflects the staging values after swap.
+3. A fast-starting app with no warm-up requirement produced 0 503s during manual swap on this single-instance P1v3 in this run (1 s probe cadence; sub-second blips could have been missed).
+4. The first post-cutover response after a warmup-configured swap had `warmed_up=true`, consistent with the platform completing the warmup path before routing live traffic **[Strongly Suggested]**.
+5. In this single-instance run, a failing Health Check endpoint on the staging slot did not block `az webapp deployment slot swap` from completing successfully.
+6. A 75 s startup delay extended swap duration (~161 s vs. ~83 s) but did not cause 503s when warm-up was configured — the transition window waited until the app was ready.
 
 ## 13. What this does NOT prove
 
-Even after execution, this experiment will not by itself prove:
-
-- That all App Service SKUs behave identically
-- That Windows/IIS slot swap behavior is identical to Linux/Python behavior
-- That every application framework reacts to warm-up the same way as this Flask app
-- That connection string behavior is identical across every connection string type
-- That auto-swap timing is identical across deployment mechanisms other than this zip deployment flow
+- That all App Service SKUs behave identically — scale-out (multiple instances) may introduce per-instance warm-up and routing differences not visible here
+- That Windows/IIS slot swap behavior is identical — `applicationInitialization` in `web.config` is the Windows equivalent; this experiment used `WEBSITE_SWAP_WARMUP_PING_PATH` on Linux
+- That Health Check failure blocks swap under any configuration — the experiment only tested the default configuration on a single-instance plan; minimum healthy instance thresholds, multi-instance plans, or other Health Check settings may change swap gating behavior **[Unknown]**
+- That Health Check is irrelevant to swap outcomes — Health Check continued to govern post-swap instance routing and eviction; a swap that succeeds with a failing health check still leaves production serving unhealthy traffic **[Observed in S3]**
+- That auto-swap (S6) follows identical timing — S6 was not executed; auto-swap couples deployment completion and swap activation and may produce a different observable timeline **[Unknown]**
+- That the observed transition window (~23 s) is guaranteed or repeatable — this was observed once per scenario at 1 s probe resolution; sub-second blips and variability across runs were not measured
+- That connection string behavior is identical across all connection string types — only `SQLAzure` type was tested
+- That the warmup path was definitively hit by the platform before cutover — this is inferred from `warmed_up=True` on the first post-cutover response; direct platform-side warmup request logs were not captured
 
 ## 14. Support takeaway
 
-Provisional guidance pending execution:
+1. **"We swapped and the app started serving the wrong config values"**: Ask explicitly which settings are marked as slot settings (`--slot-settings` / sticky). Non-sticky app settings and connection strings move with the content. If a customer expects a value to stay with an environment, it must be configured as a slot setting. This is the most common source of post-swap config confusion **[Observed]**.
 
-- When customers report wrong config after swap, explicitly separate **slot settings** from ordinary app settings and inspect connection strings independently.
-- When customers report a brief outage immediately after swap, ask whether the app needs warm-up or performs expensive startup work before serving live traffic.
-- When Health Check is enabled, verify the slot can return healthy responses on the configured path before attempting swap.
-- For auto-swap complaints, reconstruct the timeline from deployment completion, warm-up behavior, and first failed customer requests instead of assuming a pure configuration issue.
+2. **"Swap succeeded but users saw 503 for 30–60 seconds"**: The app is likely slow to start or requires an explicit warm-up call before it can serve live traffic. Confirm whether `WEBSITE_SWAP_WARMUP_PING_PATH` and `WEBSITE_SWAP_WARMUP_PING_STATUSES` are configured. If not, the platform will cut over without waiting for the app to be ready. Adding a warmup path eliminates this window for slow-starting apps **[Observed]**.
+
+3. **"Swap stalls or the swap command fails"**: In this single-instance experiment, Health Check failure did *not* block swap completion — the swap succeeded despite staging returning 503 on `/health` **[Observed]**. For swap-completion issues, start with the warm-up path: confirm `WEBSITE_SWAP_WARMUP_PING_PATH` is reachable and returns the expected status on the staging slot. If the swap command itself fails or times out, the warmup path is the more likely cause than Health Check in this configuration.
+
+4. **"Swap succeeded but production is now serving unhealthy traffic"**: Health Check failure does not prevent swap — it governs post-swap instance routing and eviction. If the swap completed and production is unhealthy, check `HEALTH_MODE` / health endpoint logic on the newly promoted slot. Health Check will eventually remove or reduce traffic to unhealthy instances, but this happens after the swap, not during it **[Observed in S3, single-instance run]**.
+
+4. **"Swap is taking much longer than usual"**: Swap duration scales with startup time plus warm-up latency. A 75 s startup + warmup produced a ~161 s swap in this test, vs. ~83 s for fast-starting apps **[Observed]**. Check actual app initialization time on the staging slot and `WARMUP_DELAY_SECONDS` or the warmup endpoint's response time.
+
+5. **Slot-sticky vs non-sticky quick reference**:
+
+    | Configured with | Behavior during swap |
+    |-----------------|----------------------|
+    | `--slot-settings` (sticky) | Stays with slot hostname; never moves |
+    | Plain `--settings` (non-sticky) | Moves with swapped content to target slot |
+
+    Connection strings follow the same rule: `--slot-settings` = sticky, plain `--settings` = moves.
 
 ## 15. Reproduction notes
 


### PR DESCRIPTION
## Summary

Executes the pre-designed `slot-swap-warmup` experiment on real Azure infrastructure (Korea Central, Linux P1v3, Python 3.11, single-instance). Updates status from **Draft** to **Published** with full scenario results.

## Scenarios Executed

| Scenario | Setup | Key finding |
|----------|-------|-------------|
| **S5** | Sticky vs non-sticky settings | Slot-sticky settings stay with hostname; non-sticky move with content — both app settings and connection strings confirmed |
| **S1** | Manual swap, no warmup, fast app | 0 503s / 120 probes; ~23s transition window where both slot identities visible at prod hostname |
| **S2** | Manual swap, warmup configured (`/warmup`, 10s delay) | 0 503s; first post-cutover response `warmed_up=True` |
| **S3** | Health Check enabled, staging `/health` returns 503 | Swap exit 0 in 83s despite staging unhealthy; prod immediately served unhealthy app |
| **S4** | 75s startup delay + warmup configured | Swap duration 161s; 0 503s — platform waited for startup + warmup before cutover |

S6 (auto-swap) not executed in this run.

## Key Findings

1. Slot-sticky settings (app settings + connection strings) remain bound to the slot hostname after swap — non-sticky values move with the content
2. A fast-starting app with no warmup requirement produced **0 503s** at 1s probe cadence during manual swap (single run)
3. Swap warmup path (`WEBSITE_SWAP_WARMUP_PING_PATH`) ensures first post-cutover response is already warmed — consistent with platform completing warmup before traffic cutover
4. **Health Check failure on staging did NOT block swap completion** in this single-instance run — swap succeeded, but prod immediately served unhealthy traffic
5. 75s startup delay extended swap from ~83s to ~161s; warmup configuration prevented any 503s during the extended wait

## Oracle Review

Applied — tightened H3/H3b/H4/H5 scope to "single run / single instance"; separated swap-completion vs post-swap Health Check guidance in support takeaway; added 1s probe cadence caveat; reframed H4 to avoid overgeneralizing from single-instance result.

## Files Changed

- `docs/app-service/slot-swap-warmup/overview.md` — Status updated to Published, Sections 10–14 fully populated