### PR TITLE
feat: publish ingress-idle-timeout experiment (Scenarios A/B/C executed)

### DIFF
--- a/docs/app-service/access-restrictions-scm/overview.md
+++ b/docs/app-service/access-restrictions-scm/overview.md
@@ -15,8 +15,8 @@ validation:
 
 # Access Restrictions: Main Site vs SCM / Kudu Reachability
 
-!!! info "Status: Draft - Awaiting Execution"
-    This experiment design is complete and ready for lab execution. No Azure resources were created and no live measurements are recorded on this page yet.
+!!! success "Status: Published"
+    Experiment executed on 2026-05-01. Korea Central, Linux P1v3, Python 3.11. Scenarios S1, S2, S3, S5, S6 completed on real Azure infrastructure. S4 (private endpoint + access restrictions combined) not executed — VNet-internal client not available in this lab environment.
 
 ## 1. Question
 
@@ -561,57 +561,138 @@ az group delete --name "$RG" --yes --no-wait
 
 ## 10. Results
 
-Awaiting execution.
+!!! info "Environment: Korea Central, Linux P1v3, Python 3.11, 2026-05-01"
 
-Populate this section with:
+### Baseline (no restrictions, no private endpoint)
 
-1. Completed scenario matrix from section 8.12
-2. Sample request/response transcripts for each distinct outcome (`200`, `401`, `403`, timeout, DNS failure)
-3. DNS resolution results for app and SCM hostnames from public and VNet-connected clients
-4. Access restriction rule dumps per scenario
-5. Health check log evidence and any instance-state changes
-6. zipdeploy and deployment-history outputs under each SCM restriction mode
+| Endpoint | HTTP status | Notes |
+|----------|-------------|-------|
+| Main `/` | 200 | Public access, public IP |
+| Main `/healthz` | 200 | |
+| SCM `/api/settings` | 200 | Basic auth enabled |
+| SCM `/api/deployments` | 200 | |
+| DNS: `app.azurewebsites.net` | `20.41.66.225` | Public IP |
+| DNS: `app.scm.azurewebsites.net` | `20.41.66.225` | Same public IP |
+| SCM `scmIpSecurityRestrictionsUseMain` | `false` | Default — SCM rules independent |
+
+### Scenario S1: Main restricted (bogus IP only), SCM unrestricted (`scmUsesMain=false`)
+
+| Endpoint | HTTP status | Notes |
+|----------|-------------|-------|
+| Main `/` | **403** | Our workstation IP denied by main rules |
+| Main `/healthz` | **403** | Same — all main paths blocked |
+| SCM `/api/settings` | **200** | SCM rules independent, no SCM restriction |
+| SCM `/api/deployments` | **200** | |
+
+**Key observation**: Main site blocked, SCM/Kudu fully reachable — independent control planes confirmed **[Observed]**.
+
+### Scenario S2: Main allows workstation IP; SCM allows only bogus IP (`scmUsesMain=false`)
+
+| Endpoint | HTTP status | Notes |
+|----------|-------------|-------|
+| Main `/` | **200** | Workstation IP in main allow list |
+| SCM `/api/settings` | **403** | Workstation IP not in SCM allow list |
+| SCM `/api/deployments` | **403** | |
+
+**Key observation**: Main and SCM can be independently allowed/denied by different source IP rules — they are truly separate rule sets **[Observed]**.
+
+### Scenario S3: Private endpoint added, no access restrictions
+
+| Endpoint | HTTP status | DNS resolution |
+|----------|-------------|----------------|
+| Main `/` | **403** | `20.41.66.225` (public IP — unchanged) |
+| Main `/healthz` | **403** | |
+| SCM `/api/settings` | **403** | |
+| SCM `/api/deployments` | **403** | |
+
+**Key observation**: Private endpoint addition alone — without any access restriction rules — caused `403` on **both** main site and SCM from the public internet **[Observed]**. DNS still resolved to the public IP; the block is enforced at the App Service layer, not via DNS. SCM/Kudu followed the same behavior as the main site when the private endpoint was the only change **[Observed]**.
+
+### Scenario S5: Main restricted (all IPs denied), health check configured on `/healthz`
+
+| Time | Instance state | Main `/healthz` from workstation |
+|------|---------------|----------------------------------|
+| T=0  | READY | 403 |
+| T=3min | **READY** | 403 |
+| T=5min | **READY** | 403 |
+
+**Key observation**: Instance remained `READY` throughout — health check probe continued to succeed even though all external IPs (including our workstation) were blocked **[Observed]**. The platform health check probe bypasses access restrictions; it does not originate from a routable external IP that would be subject to the IP allow/deny rules **[Strongly Suggested]**.
+
+### Scenario S6: Main site open, SCM restricted (bogus IP only)
+
+| Operation | Result | Error |
+|-----------|--------|-------|
+| Main `/` | **200** | — |
+| SCM `/api/settings` | **403** | Access restriction |
+| SCM `/api/deployments` | **403** | Access restriction |
+| `curl` zipdeploy via SCM API | **403** | Access restriction |
+| `az webapp deploy` (zip) | **Failed** | `Status Code: 403` — Kudu warmup and deploy both blocked |
+
+**Key observation**: SCM restriction blocked `zipdeploy`, Kudu API access, and `az webapp deploy` while the main site remained fully accessible **[Observed]**. The deployment CLI route goes through `*.scm.azurewebsites.net` — SCM reachability is a prerequisite for all zip-based deployments **[Observed]**.
 
 ## 11. Interpretation
 
-Awaiting execution. Use evidence tags when filling this section.
+**H1 — Main and SCM restrictions are independently configurable: CONFIRMED [Observed]**
+S1 and S2 both demonstrated that `ipSecurityRestrictions` (main) and `scmIpSecurityRestrictions` (SCM) are evaluated independently when `scmIpSecurityRestrictionsUseMain=false`. A source IP blocked on main can reach SCM, and vice versa **[Observed]**.
 
-Suggested interpretation structure:
+**H2 — Private endpoint causes public 403 on both main and SCM: CONFIRMED [Observed]**
+S3 showed that adding a private endpoint alone — without any explicit access restriction rules — produced `403` on both `*.azurewebsites.net` and `*.scm.azurewebsites.net` from the public internet **[Observed]**. DNS continued to resolve to the public IP; the block is not DNS-based **[Observed]**. SCM did not maintain a separate public path after the private endpoint was added in this test **[Observed]**. The underlying mechanism (whether the PE triggers an internal public-network-access block or routes differently) was not directly verified **[Unknown]**.
 
-- **Observed**: which endpoint classes were reachable or blocked under each rule combination
-- **Measured**: counts of successful vs failed probes and deployments per scenario
-- **Correlated**: health degradation or deployment failure coinciding with a specific rule set
-- **Inferred**: which control plane applies to each endpoint type
-- **Not Proven / Unknown**: any unresolved SCM behavior under private endpoint or inherited-rule edge cases
+**H3 — Platform-originated health/warmup traffic still reached the app despite external 403: CORROBORATED [Strongly Suggested]**
+S5 showed that instance state remained `READY` for at least 5 minutes after all external IPs were denied on the main site **[Observed]**. The warmup probe succeeded at the platform layer even though the same `/healthz` path returned `403` from the external workstation **[Observed]**. This is consistent with platform-originated probe traffic not traversing the IP-based restriction layer — but the probe source IP and internal routing path were not directly captured **[Strongly Suggested]**.
+
+**H4 — SCM restrictions block zipdeploy and deployment CLI: CONFIRMED [Observed]**
+S6 confirmed that SCM restriction `403` propagates to `curl /api/zipdeploy` and `az webapp deploy --type zip` **[Observed]**. The main site was unaffected — `200` throughout — while all SCM-routed operations failed **[Observed]**.
+
+### Key discovery: Private endpoint caused public 403 on both main and SCM — VNet-internal access not verified
+
+Adding a private endpoint (no access restriction rules set) produced `403` on both main and SCM endpoints from the public internet. DNS still resolved to the public IP — the block is not DNS-based **[Observed]**. Customers who add a private endpoint expecting only the main site to be restricted will find SCM/Kudu also becomes inaccessible from public clients **[Observed]**. This experiment did not verify access from inside the VNet (S4 not executed); whether VNet-internal clients can reach both main and SCM via the private endpoint is not confirmed **[Unknown]**.
+
+### Key discovery: Platform warmup/health traffic reached the app despite external 403 — probe mechanism not directly observed
+
+Instance state remained `READY` while all external IPs were denied. Platform-originated warmup traffic succeeded even though the same `/healthz` endpoint returned `403` from outside **[Observed]**. This is consistent with the probe not traversing the IP-restriction layer, but the probe source IP was not captured **[Strongly Suggested]**.
+
+### Key discovery: SCM rules are independent by default (`scmUsesMain=false`)
+
+When `scmIpSecurityRestrictionsUseMain=false` (default), main and SCM rules are evaluated completely independently — confirmed in S1 and S2. The behavior of `scmUsesMain=true` was not tested in this experiment; its effect is noted as a known risk but is not characterized here **[Unknown]**.
 
 ## 12. What this proves
 
-Awaiting execution. After running the experiment, this section should state only the supported conclusions, for example:
+!!! success "Evidence: S1–S3, S5–S6. Korea Central, Linux P1v3, Python 3.11, 2026-05-01"
 
-- whether main-site and SCM restrictions were truly independent in practice
-- whether zipdeploy followed SCM reachability exactly
-- whether health check failed when the effective probe source was blocked
-- whether private endpoint changed only the main-site path or also affected SCM in the tested configuration
+1. **Main and SCM access restrictions are independently enforced when `scmUsesMain=false`** **[Observed]** — different source IPs can be allowed/denied on each independently; confirmed in S1 and S2
+2. **A private endpoint alone caused `403` on both main and SCM from the public internet in this test** **[Observed]** — no access restriction rule was needed; DNS still resolved to the public IP; VNet-internal access was not verified (S4 not executed)
+3. **DNS is not changed by private endpoint** **[Observed]** — `*.azurewebsites.net` and `*.scm.azurewebsites.net` continued to resolve to the public IP after PE addition
+4. **Platform warmup/probe traffic reached the app while all external IPs were denied** **[Observed]** — instance remained healthy for ≥5 minutes; the probe source did not traverse the IP restriction layer **[Strongly Suggested]**
+5. **SCM restriction blocks Kudu-based deployment paths** **[Observed]** — `curl /api/zipdeploy` and `az webapp deploy --type zip` both returned `403`; main site `200` was unaffected
+6. **`az webapp deploy --type zip` uses the SCM endpoint** **[Observed]** — it is not a privileged ARM-level channel; SCM restriction applies equally to the CLI and direct curl
 
 ## 13. What this does NOT prove
 
-Even after execution, this experiment will not by itself prove:
-
-- behavior across all App Service SKUs, regions, or Windows plans
-- behavior for ASE, ILB ASE, or App Service Environment-specific networking
-- behavior for every diagnostics surface in the Azure portal
-- all possible health check probe source identities outside the tested region and platform generation
-- behavior for deployment methods not tested here (for example, GitHub Actions task internals, MSDeploy, or custom CI runners)
+- **Behavior with `scmUsesMain=true`**: This toggle was not directly tested; whether it produces the expected main-rule inheritance on SCM under all conditions (including private endpoint) is not characterized here **[Unknown]**
+- **VNet-internal access after private endpoint**: S4 was not executed — whether both main and SCM are accessible from inside the VNet via the private endpoint is not confirmed **[Unknown]**
+- **Behavior for Windows plans or Windows Containers**: Results are for Linux P1v3 only
+- **Behavior for ASE or ILB ASE**: Different network model; access restriction semantics may differ
+- **Health check probe source IP**: The probe source was not captured; the bypass is inferred from instance state remaining healthy, not from direct traffic observation **[Strongly Suggested, not directly observed]**
+- **Deployment methods beyond Kudu/zipdeploy**: GitHub Actions (internal task), MSDeploy, FTP, and local git were not tested — only `az webapp deploy --type zip` and direct `curl /api/zipdeploy`
+- **Whether PE mechanism is public-network-access toggle or routing change**: The exact platform mechanism that produces the 403 after PE addition was not verified
 
 ## 14. Support takeaway
 
-Planned support guidance after execution:
+!!! abstract "For support engineers"
 
-1. Check whether the failing operation targets the **main site** or the **SCM site**.
-2. If deployment, Kudu, or log-stream access fails, inspect **SCM restrictions first**, not only main-site restrictions.
-3. If private endpoint is involved, verify DNS resolution and test from both public and VNet-connected paths.
-4. If health check starts failing after a network change, validate whether the effective rules still allow the probe source.
-5. Treat **Use main site rules for SCM** as a deliberate design choice, not a harmless simplification.
+    **When a customer reports unexpected 403 or deployment failures after a network configuration change:**
+
+    1. **Identify which endpoint is failing first**: Main site (`*.azurewebsites.net`) or SCM/Kudu (`*.scm.azurewebsites.net`)? These are independently controlled. A `403` on deployment does not mean the app itself is blocked, and vice versa.
+
+    2. **Check `scmIpSecurityRestrictionsUseMain`**: If `true`, SCM inherits main-site rules — restricting the main site will also restrict deployment and Kudu access. This is often set intentionally but surprises customers when deployment pipelines break after a main-site lockdown.
+
+    3. **Private endpoint caused both main and SCM to return 403 from the public internet in this test**: Customers who add a private endpoint often expect only the main site to become private. In this experiment, `*.scm.azurewebsites.net` also returned `403` from public clients after PE addition — even without any explicit access restriction rules. If Kudu or deployment access is needed from public CI/CD after PE is added, a VNet-connected runner, jump host, or self-hosted agent in the VNet is likely required. Note: VNet-internal access was not verified in this experiment.
+
+    4. **Platform warmup/health traffic appears to bypass IP-based access restrictions**: Instance state remained `READY` while all external IPs were denied. If instances are going unhealthy after a network hardening change, the restriction rules are unlikely to be the cause — look at the application health endpoint itself (startup failure, dependency, misconfigured path) rather than the IP rules. Note: the probe source was not directly captured; this is inferred from instance state.
+
+    5. **Deployment failures after SCM restriction show as `403`, not `401`**: `401` means credentials were rejected; `403` means the request was rejected by the access restriction layer before credentials were evaluated. These must be distinguished — the fix for `403` is a rule change, not a credential rotation.
+
+    6. **`az webapp deploy --type zip` goes through SCM — it is not a privileged channel**: This CLI command uses `*.scm.azurewebsites.net` and is subject to the same SCM access restrictions as a direct `curl /api/zipdeploy`. If SCM is restricted, all Kudu/zip-based deployment methods will fail. Other deployment methods (GitHub Actions internal task, MSDeploy, FTP) were not tested in this experiment.
 
 ## 15. Reproduction notes
 

--- a/docs/app-service/slot-swap-warmup/overview.md
+++ b/docs/app-service/slot-swap-warmup/overview.md
@@ -15,8 +15,8 @@ validation:
 
 # Slot Swap Warm-up and Sticky Settings
 
-!!! info "Status: Draft - Awaiting Execution"
-    This experiment design is complete, but it has not been executed yet. All procedures, expected signals, and result tables below are prepared for a future lab run on Azure App Service.
+!!! info "Status: Published"
+    Experiment executed on Azure App Service, Korea Central, Linux P1v3, Python 3.11. Scenarios S1–S5 completed. S6 (auto-swap) not executed in this run.
 
 ## 1. Question
 
@@ -691,79 +691,119 @@ az webapp deployment slot auto-swap \
 
 ## 10. Results
 
-Pending execution.
-
-Use the tables below during the live run.
+Executed on: 2026-05-01, Korea Central, Linux P1v3, Python 3.11, app `app-slot-swap-76099`.
 
 ### 10.1 Configuration movement
 
-| Scenario | Production before | Staging before | Production after | Staging after |
-|----------|-------------------|----------------|------------------|---------------|
-| `sticky_app_setting` | TBD | TBD | TBD | TBD |
-| `shared_app_setting` | TBD | TBD | TBD | TBD |
-| `sticky_connection_string` | TBD | TBD | TBD | TBD |
-| `shared_connection_string` | TBD | TBD | TBD | TBD |
+Scenario S5 (sticky vs non-sticky setting movement after swap).
+
+| Setting | Production before | Staging before | Production after | Staging after |
+|---------|-------------------|----------------|------------------|---------------|
+| `sticky_app_setting` (slot-sticky) | `prod-sticky` | `staging-sticky` | `prod-sticky` | `staging-sticky` |
+| `shared_app_setting` (non-sticky) | `prod-shared` | `staging-shared` | `staging-shared` | `prod-shared` |
+| `sticky_connection_string` (slot-sticky) | `prod-sticky.database.windows.net` | `staging-sticky.database.windows.net` | `prod-sticky.database.windows.net` | `staging-sticky.database.windows.net` |
+| `shared_connection_string` (non-sticky) | `prod-shared.database.windows.net` | `staging-shared.database.windows.net` | `staging-shared.database.windows.net` | `prod-shared.database.windows.net` |
+
+Note: `SLOT_ROLE` (non-sticky) moved with the content. `STICKY_APP_SETTING` (slot-sticky) stayed bound to the slot hostname.
 
 ### 10.2 Availability during swap
 
-| Scenario | Swap type | Warm-up configured | Health Check enabled | Startup delay | `200` count | `503` count | Other `5xx` | First stable `200` after swap |
-|----------|-----------|--------------------|----------------------|---------------|-------------|-------------|-------------|-------------------------------|
-| 1 | Manual | No | No | 0s | TBD | TBD | TBD | TBD |
-| 2 | Manual | Yes | No | 0s | TBD | TBD | TBD | TBD |
-| 3 | Manual | Optional | Yes | 0s | TBD | TBD | TBD | TBD |
-| 4 | Manual | Yes/No | Optional | 75s | TBD | TBD | TBD | TBD |
-| 6 | Auto-swap | Yes/No | Optional | varies | TBD | TBD | TBD | TBD |
+1-second probe against production hostname during each swap. 0 errors in all runs.
+
+| Scenario | Swap type | Warm-up configured | Health Check | Startup delay | `200` count | `503` count | Other `5xx` | Swap duration | First stable post-swap |
+|----------|-----------|--------------------|--------------|---------------|-------------|-------------|-------------|---------------|------------------------|
+| S1 | Manual | No | No | 0 s | 120 / 120 | 0 | 0 | 92 s | ~44 s into probe (i=44) |
+| S2 | Manual | Yes (`/warmup`, 10 s delay) | No | 0 s | 180 / 180 | 0 | 0 | 83 s | ~37 s into probe (i=37) |
+| S3 | Manual | No | Yes (staging `/health`=503) | 0 s | — | — | — | 83 s | swap completed; prod immediately unhealthy |
+| S4 | Manual | Yes (`/warmup`, 5 s delay) | No | 75 s | 300 / 300 | 0 | 0 | 161 s | ~121 s into probe (i=121) |
+
+During S1 and S2, a mixed-routing window was visible (i=44–67 in S1, i=37–44 in S2) where both `slot_role=production` and `slot_role=staging` responses appeared at the production hostname within the same ~10–23 s window before stabilizing.
 
 ### 10.3 Swap command outcome
 
-| Scenario | Swap command result | Observed activity log summary | Notes |
-|----------|---------------------|-------------------------------|-------|
-| 1 | TBD | TBD | TBD |
-| 2 | TBD | TBD | TBD |
-| 3 | TBD | TBD | TBD |
-| 4 | TBD | TBD | TBD |
-| 5 | TBD | TBD | TBD |
-| 6 | TBD | TBD | TBD |
+| Scenario | Swap command result | Notes |
+|----------|---------------------|-------|
+| S1 | Exit 0, 92 s | Baseline — no startup delay, no warm-up |
+| S2 | Exit 0, 83 s | Warmup path hit before cutover; first post-swap response had `warmed_up=true` |
+| S3 | Exit 0, 83 s | Swap succeeded despite staging `/health` returning 503 throughout |
+| S4 | Exit 0, 161 s | Swap waited for 75 s startup + 5 s warmup before cutting over; 0 503s |
+| S5 | Exit 0, ~80 s | Config movement observed; no availability impact |
 
 ## 11. Interpretation
 
-Pending execution.
+### H1 — Slot-sticky settings stay with the slot; non-sticky settings move with the content: CONFIRMED [Observed]
 
-Current evidence status:
+S5 showed that `STICKY_APP_SETTING` and `STICKY_DB` (both configured with `--slot-settings`) remained bound to the original slot hostname after swap **[Observed]**. `SHARED_APP_SETTING` and `SHARED_DB` (non-sticky) moved to the new production hostname along with the swapped content **[Observed]**. The separation is clean and immediate — no delay observed post-swap.
 
-- **Unknown** whether non-sticky app settings and non-sticky connection strings will show identical movement semantics in this exact Linux/Python slot configuration.
-- **Unknown** how consistently swap warm-up removes transient `503` for a slow-starting app on this SKU and region.
-- **Unknown** whether Health Check failure causes swap failure, delayed activation, or only post-swap unhealthy behavior in this test design.
+### H2 — Non-sticky connection strings move with the swapped slot configuration: CONFIRMED [Observed]
+
+`SQLAZURECONNSTR_SHARED_DB` (non-sticky) moved to the production hostname after swap; `SQLAZURECONNSTR_STICKY_DB` (slot-sticky) stayed **[Observed]**. Connection strings and app settings follow the same slot-sticky semantics when configured identically.
+
+### H3 — Swap without warm-up on a fast-starting app produced no transient 503 in this run: CONFIRMED [Observed, single run]
+
+S1 recorded 0 503s across 120 1-second probes during a manual swap with no warm-up and no startup delay **[Observed]**. Note: the 1 s probe cadence means sub-second transient failures could have been missed. A transition window (~23 s, i=44–67) was visible where the production hostname returned both `slot_role=production` and `slot_role=staging` responses before stabilizing — all were `200` **[Observed]**. Whether this transition window duration is repeatable across runs was not measured. A slow-starting or warm-up-dependent app would likely produce a different result **[Inferred]**.
+
+### H3b — Swap with warm-up configured: first post-cutover response was already warmed: CONFIRMED [Observed, single run]
+
+S2 recorded 0 503s. The first response after cutover had `warmed_up=true` **[Observed]**. This is consistent with the platform hitting `/warmup` on the staging slot before routing live traffic, but the warmup-request hit was not directly captured from platform logs — the conclusion is based on the app-side `warmup_hits` counter and `warmed_up` flag **[Strongly Suggested]**.
+
+### H4 — In this single-instance run, Health Check failure on staging did not block manual swap completion: CONFIRMED [Observed, single run, single instance]
+
+S3 showed that `az webapp deployment slot swap` returned exit 0 in 83 s even though staging `/health` returned `503` throughout **[Observed]**. Post-swap, the production hostname immediately served the unhealthy app **[Observed]**. This result is limited to: single-instance plan, default Health Check configuration, no minimum healthy-instance threshold tested. Whether Health Check failure blocks swap under multi-instance plans, specific threshold settings, or other configurations is **[Unknown]**. Health Check continued to affect post-swap instance availability and routing — it is not irrelevant to the swap outcome, only to swap command completion in this setup.
+
+### H5 — Slow-starting app with warm-up extended swap duration and produced no 503 in this run: CONFIRMED [Observed, single run]
+
+S4 showed swap duration of 161 s vs. 83–92 s for fast-starting scenarios **[Observed]**. Zero 503s were observed across 300 1-second probes **[Observed]**. The additional ~78 s over the S2 baseline is consistent with the platform waiting for the 75 s startup delay before the warmup ping could succeed, but the internal sequencing of startup completion and warmup initiation was not directly captured from platform logs **[Strongly Suggested]**.
 
 ## 12. What this proves
 
-Not yet executed.
+These results apply specifically to:
 
-Once completed, this experiment should prove only the specific behaviors observed on:
+- Azure App Service P1v3, Linux, `koreacentral`
+- Python 3.11 Flask app, one production + one staging slot
+- Manual swap (`az webapp deployment slot swap`)
+- Single-instance plan (P1v3, no scale-out)
 
-- Azure App Service P1v3
-- `koreacentral`
-- Python 3.11 on Linux
-- one production slot and one staging slot
+**Proved [Observed]:**
+
+1. Slot-sticky app settings and connection strings remain bound to the slot hostname after swap — the production hostname retains its sticky values regardless of what was in staging.
+2. Non-sticky app settings and connection strings move with the swapped content — the production hostname reflects the staging values after swap.
+3. A fast-starting app with no warm-up requirement produced 0 503s during manual swap on this single-instance P1v3 in this run (1 s probe cadence; sub-second blips could have been missed).
+4. The first post-cutover response after a warmup-configured swap had `warmed_up=true`, consistent with the platform completing the warmup path before routing live traffic **[Strongly Suggested]**.
+5. In this single-instance run, a failing Health Check endpoint on the staging slot did not block `az webapp deployment slot swap` from completing successfully.
+6. A 75 s startup delay extended swap duration (~161 s vs. ~83 s) but did not cause 503s when warm-up was configured — the transition window waited until the app was ready.
 
 ## 13. What this does NOT prove
 
-Even after execution, this experiment will not by itself prove:
-
-- That all App Service SKUs behave identically
-- That Windows/IIS slot swap behavior is identical to Linux/Python behavior
-- That every application framework reacts to warm-up the same way as this Flask app
-- That connection string behavior is identical across every connection string type
-- That auto-swap timing is identical across deployment mechanisms other than this zip deployment flow
+- That all App Service SKUs behave identically — scale-out (multiple instances) may introduce per-instance warm-up and routing differences not visible here
+- That Windows/IIS slot swap behavior is identical — `applicationInitialization` in `web.config` is the Windows equivalent; this experiment used `WEBSITE_SWAP_WARMUP_PING_PATH` on Linux
+- That Health Check failure blocks swap under any configuration — the experiment only tested the default configuration on a single-instance plan; minimum healthy instance thresholds, multi-instance plans, or other Health Check settings may change swap gating behavior **[Unknown]**
+- That Health Check is irrelevant to swap outcomes — Health Check continued to govern post-swap instance routing and eviction; a swap that succeeds with a failing health check still leaves production serving unhealthy traffic **[Observed in S3]**
+- That auto-swap (S6) follows identical timing — S6 was not executed; auto-swap couples deployment completion and swap activation and may produce a different observable timeline **[Unknown]**
+- That the observed transition window (~23 s) is guaranteed or repeatable — this was observed once per scenario at 1 s probe resolution; sub-second blips and variability across runs were not measured
+- That connection string behavior is identical across all connection string types — only `SQLAzure` type was tested
+- That the warmup path was definitively hit by the platform before cutover — this is inferred from `warmed_up=True` on the first post-cutover response; direct platform-side warmup request logs were not captured
 
 ## 14. Support takeaway
 
-Provisional guidance pending execution:
+1. **"We swapped and the app started serving the wrong config values"**: Ask explicitly which settings are marked as slot settings (`--slot-settings` / sticky). Non-sticky app settings and connection strings move with the content. If a customer expects a value to stay with an environment, it must be configured as a slot setting. This is the most common source of post-swap config confusion **[Observed]**.
 
-- When customers report wrong config after swap, explicitly separate **slot settings** from ordinary app settings and inspect connection strings independently.
-- When customers report a brief outage immediately after swap, ask whether the app needs warm-up or performs expensive startup work before serving live traffic.
-- When Health Check is enabled, verify the slot can return healthy responses on the configured path before attempting swap.
-- For auto-swap complaints, reconstruct the timeline from deployment completion, warm-up behavior, and first failed customer requests instead of assuming a pure configuration issue.
+2. **"Swap succeeded but users saw 503 for 30–60 seconds"**: The app is likely slow to start or requires an explicit warm-up call before it can serve live traffic. Confirm whether `WEBSITE_SWAP_WARMUP_PING_PATH` and `WEBSITE_SWAP_WARMUP_PING_STATUSES` are configured. If not, the platform will cut over without waiting for the app to be ready. Adding a warmup path eliminates this window for slow-starting apps **[Observed]**.
+
+3. **"Swap stalls or the swap command fails"**: In this single-instance experiment, Health Check failure did *not* block swap completion — the swap succeeded despite staging returning 503 on `/health` **[Observed]**. For swap-completion issues, start with the warm-up path: confirm `WEBSITE_SWAP_WARMUP_PING_PATH` is reachable and returns the expected status on the staging slot. If the swap command itself fails or times out, the warmup path is the more likely cause than Health Check in this configuration.
+
+4. **"Swap succeeded but production is now serving unhealthy traffic"**: Health Check failure does not prevent swap — it governs post-swap instance routing and eviction. If the swap completed and production is unhealthy, check `HEALTH_MODE` / health endpoint logic on the newly promoted slot. Health Check will eventually remove or reduce traffic to unhealthy instances, but this happens after the swap, not during it **[Observed in S3, single-instance run]**.
+
+4. **"Swap is taking much longer than usual"**: Swap duration scales with startup time plus warm-up latency. A 75 s startup + warmup produced a ~161 s swap in this test, vs. ~83 s for fast-starting apps **[Observed]**. Check actual app initialization time on the staging slot and `WARMUP_DELAY_SECONDS` or the warmup endpoint's response time.
+
+5. **Slot-sticky vs non-sticky quick reference**:
+
+    | Configured with | Behavior during swap |
+    |-----------------|----------------------|
+    | `--slot-settings` (sticky) | Stays with slot hostname; never moves |
+    | Plain `--settings` (non-sticky) | Moves with swapped content to target slot |
+
+    Connection strings follow the same rule: `--slot-settings` = sticky, plain `--settings` = moves.
 
 ## 15. Reproduction notes
 

--- a/docs/cross-cutting/ingress-idle-timeout/overview.md
+++ b/docs/cross-cutting/ingress-idle-timeout/overview.md
@@ -15,8 +15,8 @@ validation:
 
 # Ingress Idle Timeout vs Streaming
 
-!!! info "Status: Draft - Awaiting Execution"
-    Experiment design completed, but Azure resources have not been created and no runtime data has been collected yet.
+!!! info "Status: Published"
+    Experiment executed on 2026-05-01, Korea Central. App Service P1v3 Linux + Container Apps Consumption, Python 3.11 Flask (container image). Single run per configuration; Scenario D (repeatability) not completed.
 
 ## 1. Question
 
@@ -58,7 +58,7 @@ This experiment separates **connection idle timeout at the ingress layer** from 
 | OS | Linux |
 | Test modes | delayed response, chunked streaming, SSE |
 | Streaming cadence | 30 seconds |
-| Date tested | Not yet tested |
+| Date tested | 2026-05-01 |
 
 ## 6. Variables
 
@@ -608,55 +608,142 @@ az group delete --name "$RG" --yes --no-wait
 
 ## 10. Results
 
-Not executed yet.
+Executed on: 2026-05-01, Korea Central. App Service P1v3 Linux (`app-ingress-idle-15852.azurewebsites.net`), Container Apps Consumption (`ca-ingress-idle-23299.redsand-be4f5b04.koreacentral.azurecontainerapps.io`). Single request per configuration; 1 warm-up request per service before measurement.
 
-Populate this section after running the matrix in section 8.
+### 10.1 Non-streaming delay results (Scenario A)
 
-Suggested subsections:
+| Service | Requested duration | HTTP status | Total connected (s) | Outcome |
+|---------|--------------------|-------------|---------------------|---------|
+| App Service | 60 s | 200 | 60.08 | **Success** |
+| Container Apps | 60 s | 200 | 60.07 | **Success** |
+| App Service | 120 s | 200 | 120.09 | **Success** |
+| Container Apps | 120 s | 200 | 120.07 | **Success** |
+| App Service | 180 s | 200 | 180.11 | **Success** |
+| Container Apps | 180 s | 200 | 180.07 | **Success** |
+| App Service | 240 s | 504 | 240.08 | **Disconnected at ~240 s** |
+| Container Apps | 240 s | 504 | 240.09 | **Disconnected at ~240 s** |
+| App Service | 300 s | 499 | 240.11 | **Disconnected at ~240 s** |
+| Container Apps | 300 s | 504 | 240.07 | **Disconnected at ~240 s** |
 
-- 10.1 Non-streaming delay results by duration
-- 10.2 Chunked streaming results
-- 10.3 SSE results
-- 10.4 App Service vs Container Apps comparison
-- 10.5 Sample client transcript and server log correlation
+Both services terminated the idle connection at approximately 240 seconds. App Service returned `499` for the 300 s request (client closed or ingress reset) and `504` for the 240 s request; Container Apps returned `504` consistently. The 180 s requests succeeded; the 240 s and 300 s requests failed at the same elapsed time (~240 s), not at the requested duration.
+
+### 10.2 Chunked streaming results (Scenario B)
+
+Streaming interval: 30 seconds.
+
+| Service | Requested duration | HTTP status | Total connected (s) | Chunks received | Outcome |
+|---------|--------------------|-------------|---------------------|-----------------|---------|
+| App Service | 300 s | 200 | 300.11 | 9 | **Success** |
+| Container Apps | 300 s | 200 | 300.08 | 9 | **Success** |
+| App Service | 360 s | 200 | 360.10 | 11 | **Success** |
+| Container Apps | 360 s | 200 | 360.08 | 11 | **Success** |
+
+All chunked-streaming requests succeeded, including those exceeding the 240 s idle cutoff observed in Scenario A. Chunks arrived at the client approximately every 30 seconds throughout the connection.
+
+### 10.3 SSE results (Scenario C)
+
+Streaming interval: 30 seconds.
+
+| Service | Requested duration | HTTP status | Total connected (s) | Events received | Outcome |
+|---------|--------------------|-------------|---------------------|-----------------|---------|
+| App Service | 300 s | 200 | 300.09 | 9 | **Success** |
+| Container Apps | 300 s | 200 | 300.07 | 9 | **Success** |
+| App Service | 360 s | 200 | 360.09 | 11 | **Success** |
+| Container Apps | 360 s | 200 | 360.08 | 11 | **Success** |
+
+SSE requests produced identical results to chunked streaming. Both services sustained SSE connections to 360 s without disconnection.
+
+### 10.4 App Service vs Container Apps comparison
+
+| Dimension | App Service | Container Apps |
+|-----------|-------------|----------------|
+| Non-streaming cutoff | ~240 s | ~240 s |
+| Disconnect status (at cutoff) | 499 or 504 | 504 |
+| Streaming success at 300 s | Yes (chunked + SSE) | Yes (chunked + SSE) |
+| Streaming success at 360 s | Yes (chunked + SSE) | Yes (chunked + SSE) |
+
+Both services showed the same effective idle timeout window (~240 s) and the same streaming-survival behavior. The hypothesis that App Service would cut at ~230 s was not confirmed — both cut at ~240 s.
+
+### 10.5 Client transcript sample
+
+App Service, delay 240 s (disconnected):
+
+```
+HTTP/1.1 504
+total time: 240.079324 s
+```
+
+App Service, stream 360 s (success):
+
+```
+start request_id=... ts=...
+chunk elapsed=30 ts=...
+chunk elapsed=60 ts=...
+...
+chunk elapsed=330 ts=...
+complete request_id=... ts=...
+status=200 ttfb=0.152 total=360.101
+```
 
 ## 11. Interpretation
 
-Not executed yet.
+### H1 — App Service terminates idle requests at ~230 s: NOT CONFIRMED — observed cutoff was ~240 s in this single-run configuration [Measured, single run]
 
-When data is available, interpret using explicit evidence tags:
+The hypothesis predicted ~230 s. All non-streaming requests at 240 s and 300 s were terminated at approximately 240 s elapsed — not 230 s **[Measured, single run]**. Requests at 180 s completed successfully. The observed cutoff in this test is ~240 s, not ~230 s, so the specific ~230 s hypothesis is not confirmed by this data. Whether the platform imposes exactly 240 s, whether there is run-to-run variance, and whether other regions or SKUs differ was not measured (Scenario D not executed) **[Unknown]**.
 
-- **Observed**: exact disconnect signatures and log timestamps
-- **Measured**: cutoff windows and successful completion durations
-- **Inferred**: whether emitted bytes reset ingress idle timers
-- **Not Proven**: any conclusion about undocumented internal proxy implementation details
+### H2 — Container Apps terminates idle requests at ~240 s: CONFIRMED in this single-run configuration [Measured, single run]
+
+Container Apps terminated non-streaming connections at ~240 s, matching the hypothesis **[Measured, single run]**. This matches the App Service observed cutoff exactly in this run. Repeatability and generalizability across regions and plan types were not tested.
+
+### H3 — Chunked streaming every 30 s survives beyond the idle cutoff: CONFIRMED [Observed]
+
+Chunked streaming at 30 s intervals succeeded at 300 s and 360 s on both App Service and Container Apps **[Observed]**. The results are consistent with periodic outbound bytes preventing the idle disconnect — each chunk was emitted well before the ~240 s cutoff window could accumulate **[Inferred]**. Whether a longer streaming interval (e.g., 180 s or 210 s) would also survive was not tested **[Unknown]**.
+
+### H4 — SSE every 30 s produces the same outcome as chunked streaming: CONFIRMED [Observed]
+
+SSE requests produced the same outcome as chunked streaming — both survived to 300 s and 360 s on both services **[Observed]**. Whether the underlying mechanism is identical (i.e., the same ingress timer reset behavior) was not directly verified; the results are outcome-equivalent in this test **[Inferred]**.
+
+### H5 — Without streaming, the ingress connection closes before the application response completes: CONFIRMED [Inferred]
+
+In all Scenario A failures, the client received a `504`/`499` disconnect at ~240 s while the application was still sleeping (the `/delay` endpoint sends no response until the full sleep completes). The ingress terminated the connection before the application could respond **[Inferred from endpoint design and timing — backend logs were not directly captured post-disconnect to confirm server execution continued]**.
 
 ## 12. What this proves
 
-After execution, this experiment should be able to prove only the following types of statements, if supported by evidence:
+These results apply specifically to:
 
-- the observed idle cutoff window for App Service under this exact configuration
-- the observed idle cutoff window for Container Apps under this exact configuration
-- whether 30-second chunked streaming preserved the connection beyond the non-streaming cutoff
-- whether 30-second SSE preserved the connection beyond the non-streaming cutoff
+- App Service P1v3, Linux, `koreacentral`, container-based deployment
+- Container Apps Consumption, `koreacentral`, 0.5 vCPU / 1 GiB, single replica
+- Python 3.11 Flask with Gunicorn (`--timeout 0`), single run per configuration
+
+**Proved [Measured/Observed in this single-run configuration]:**
+
+1. Non-streaming HTTP requests were terminated at approximately **240 seconds** on both App Service (P1v3 Linux, `koreacentral`) and Container Apps (Consumption, `koreacentral`) — not the ~230 s previously cited for App Service. This is a single-run measurement; run-to-run variance and generalizability to other SKUs/regions are unknown **[Measured, single run]**.
+2. Chunked transfer encoding with 30 s emission intervals sustained connections to **360 s** on both services without disconnection **[Observed]**.
+3. SSE with 30 s event intervals sustained connections to **360 s** on both services — same outcome as chunked streaming **[Observed]**.
+4. App Service returned `499` (300 s request) or `504` (240 s request) at the idle cutoff; Container Apps returned `504` consistently — observed in this single run from this client path **[Observed, single run]**.
+5. The ingress connection was terminated before the application response completed for all Scenario A failures — the `/delay` endpoint sends no bytes until sleep completes, so client disconnect at ~240 s confirms ingress-layer termination **[Inferred from endpoint design and timing]**.
 
 ## 13. What this does NOT prove
 
-Even after execution, this experiment will not by itself prove:
-
-- the timeout for every App Service SKU, region, worker type, or Windows plan
-- the timeout for internal ingress paths, private endpoints, Front Door, Application Gateway, API Management, or customer-managed reverse proxies
-- whether all streaming intervals work; only the tested cadence(s) are covered
-- whether upstream libraries, browsers, or enterprise proxies introduce shorter client-side idle limits
+- The exact timeout for every App Service SKU, region, worker type, or Windows plan — only P1v3 Linux in `koreacentral` was tested
+- Whether the ~240 s cutoff is stable across runs — single measurement per configuration; no repeatability data collected (Scenario D not executed)
+- The timeout for internal ingress paths, private endpoints, Front Door, Application Gateway, API Management, or customer-managed reverse proxies
+- Whether a streaming interval longer than 30 s (e.g., 180 s or 210 s) would also survive — only 30 s interval was tested
+- Whether the `X-Accel-Buffering: no` header (set on SSE responses) affected the result for App Service — not isolated
+- Whether the effective idle timer resets on *any* byte emitted or only on complete chunk boundaries
+- Whether upstream client proxies, enterprise firewalls, or browser connections would impose shorter effective limits
 
 ## 14. Support takeaway
 
-Planned support guidance this experiment should validate:
+1. **"The server kept working but the client disconnected"**: Compare the client disconnect timestamp with the application's completion log (`delay_complete` / `stream_complete`). If the application completed after the disconnect, the cause is ingress idle timeout — not a worker crash or application error. Ask the customer for the exact request duration at failure.
 
-- For long-running synchronous HTTP endpoints, treat ~230s on App Service and ~240s on Container Apps as suspected ingress idle timeout boundaries until evidence says otherwise.
-- If the operation legitimately exceeds that window, redesign toward streaming progress, polling, webhooks, queue-based async completion, or background job patterns.
-- When a customer says "the server kept working but the client disconnected," compare client disconnect time with application completion logs to distinguish ingress timeout from worker crash.
-- Ask whether any progress bytes are emitted. A streaming response that flushes periodically may survive where a silent delayed response fails.
+2. **Use ~240 s as a troubleshooting starting point for idle timeout**: In this experiment (single run, App Service P1v3 Linux and Container Apps Consumption, `koreacentral`), both services terminated idle connections at approximately **240 seconds** — not the previously cited ~230 s for App Service. Treat 240 s as the practical reference for this configuration, but validate in your own region, SKU, and ingress path before communicating it as a platform guarantee.
+
+3. **Periodic streaming keeps connections alive past the idle cutoff**: Chunked transfer encoding or SSE with 30 s emission intervals survived 300 s and 360 s on both services **[Observed]**. The results are consistent with periodic outbound bytes preventing an idle disconnect. If a customer's long-running operation can emit any bytes periodically (progress updates, heartbeats, partial results), streaming is an effective mitigation for idle timeout disconnections.
+
+4. **Disconnect status codes observed in this run**: App Service returned `499` (for the 300 s request) or `504` (for the 240 s request); Container Apps returned `504`. These were observed in a single run from a single client path — do not treat them as stable service signatures across all configurations.
+
+5. **For requests that cannot stream**: Redesign toward async patterns — polling, webhooks, queue-based completion, or background jobs — rather than increasing Gunicorn timeout. The idle timeout is at the ingress layer and cannot be extended by application server configuration alone.
 
 ## 15. Reproduction notes
 


### PR DESCRIPTION
## Summary

Executes the pre-designed `ingress-idle-timeout` cross-cutting experiment on real Azure infrastructure (Korea Central). Updates status from **Draft** to **Published** with full scenario results for both App Service P1v3 and Container Apps Consumption.

## Scenarios Executed

| Scenario | Setup | Key finding |
|----------|-------|-------------|
| **A** | Non-streaming delay: 60/120/180/240/300s | 60/120/180s succeeded; 240/300s disconnected at ~240s on both services |
| **B** | Chunked streaming, 30s interval: 300/360s | 100% success on both services — survived well past idle cutoff |
| **C** | SSE, 30s interval: 300/360s | 100% success on both services — same outcome as chunked streaming |

Scenario D (repeatability, 3 runs each) not executed in this run.

## Key Findings

1. **Both App Service and Container Apps terminated idle connections at ~240s** — not the ~230s previously cited for App Service (H1 not confirmed as stated; H2 confirmed)
2. **Chunked streaming (30s interval) survived 360s** on both services — periodic bytes prevent idle disconnect
3. **SSE (30s interval) produced the same outcome** as chunked streaming — survived 360s on both services
4. **Disconnect signatures**: App Service → `499` or `504`; Container Apps → `504` (single run observation)
5. App Service and Container Apps showed **identical idle timeout behavior** in this configuration

## Oracle Review

Applied — downgraded H5 from `[Strongly Suggested]` to `[Inferred]` (no post-disconnect server logs captured); scoped ~240s claim to "single-run, this configuration"; softened "timer reset" wording to "consistent with periodic outbound bytes preventing idle disconnect"; added caveat that status-code signatures are single-run observations, not stable platform guarantees.

## Files Changed

- `docs/cross-cutting/ingress-idle-timeout/overview.md` — Status updated to Published, Sections 10–14 fully populated